### PR TITLE
Categorize, BOM, dependabot, and new Jenkins base version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Per https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+  target-branch: master
+  reviewers:
+  - olivergondza
+  labels:
+  - skip-changelog

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.2</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <url>https://github.com/jenkinsci/implied-labels-plugin</url>
 
   <scm>
-    <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
     <url>https://github.com/${gitHubRepo}</url>
     <tag>${scmTag}</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -21,17 +21,27 @@
     <tag>HEAD</tag>
   </scm>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.263.x</artifactId>
+        <version>984.vb5eaac999a7e</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
-      <version>2.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-auth</artifactId>
-      <version>2.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,8 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.55</version>
+    <version>4.29</version>
+    <relativePath />
   </parent>
 
   <artifactId>implied-labels</artifactId>
@@ -50,7 +51,7 @@
   </pluginRepositories>
 
   <properties>
-    <jenkins.version>2.150</jenkins.version>
+    <jenkins.version>2.263.1</jenkins.version>
     <java.level>8</java.level>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,8 @@
   <dependencies>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
+      <artifactId>hamcrest</artifactId>
+      <version>2.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -8,17 +8,17 @@
   </parent>
 
   <artifactId>implied-labels</artifactId>
-  <version>0.9-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
   <name>Implied Labels Plugin</name>
   <description>Infer redundant labels automatically based on user declaration</description>
   <url>https://github.com/jenkinsci/implied-labels-plugin</url>
 
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/implied-labels-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/implied-labels-plugin.git</developerConnection>
-    <url>https://github.com/jenkinsci/implied-labels-plugin</url>
-    <tag>HEAD</tag>
+    <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <url>https://github.com/${gitHubRepo}</url>
+    <tag>${scmTag}</tag>
   </scm>
 
   <dependencyManagement>
@@ -61,6 +61,9 @@
   </pluginRepositories>
 
   <properties>
+    <revision>0.9</revision>
+    <changelist>-SNAPSHOT</changelist>
+    <gitHubRepo>jenkinsci/implied-labels-plugin</gitHubRepo>
     <jenkins.version>2.263.1</jenkins.version>
     <java.level>8</java.level>
 

--- a/src/main/java/org/jenkinsci/plugins/impliedlabels/Config.java
+++ b/src/main/java/org/jenkinsci/plugins/impliedlabels/Config.java
@@ -84,6 +84,11 @@ public class Config extends ManagementLink {
         }
     }
 
+    @Override
+    public ManagementLink.Category getCategory() {
+        return ManagementLink.Category.CONFIGURATION;
+    }
+
     public String getDisplayName() {
         return "Label implications";
     }


### PR DESCRIPTION
## Categorize, BOM, Dependabot, and new Jenkins base version

* Categorize the plugin in "System Configuration" 
* Require Jenkins 2.263.1 or newer (so we can use the bom)
* Use plugin bom to provide dependency versions
* Use documentation as code for plugin docs
* Configure dependabot to update dependencies