### PR TITLE
Use hamcrest assertThat, not JUnit assertThat

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/impliedlabels/ImplicationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/impliedlabels/ImplicationTest.java
@@ -24,7 +24,7 @@
 package org.jenkinsci.plugins.impliedlabels;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import hudson.model.labels.LabelAtom;
 
 import java.io.IOException;


### PR DESCRIPTION
## Use Hamcrest `assertThat`, not JUnit `assertThat`

JUnit assertThat is deprecated

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
