### PR TITLE
Remove deprecated jelly singletonList call

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/impliedlabels/Config/configure.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/impliedlabels/Config/configure.jelly
@@ -30,7 +30,7 @@ THE SOFTWARE.
         <l:task icon="icon-gear2 icon-md" href="${rootURL}/manage" title="${%Manage_Jenkins}" permission="${app.ADMINISTER}" />
         <l:task icon="icon-up icon-md" href="." title="${it.displayName}" permission="${app.ADMINISTER}" />
       </l:tasks>
-      <t:executors computers="${h.singletonList(it)}" />
+      <t:executors computers="${[it]}"/>
     </l:side-panel>
 
     <l:main-panel>

--- a/src/main/resources/org/jenkinsci/plugins/impliedlabels/Config/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/impliedlabels/Config/index.jelly
@@ -53,7 +53,7 @@ THE SOFTWARE.
         <l:task icon="icon-gear2 icon-md" href="${rootURL}/manage" title="${%Manage_Jenkins}" permission="${app.ADMINISTER}" />
         <l:task icon="icon-setting icon-md" href="configure" title="${%Configure}" permission="${app.ADMINISTER}" />
       </l:tasks>
-      <t:executors computers="${h.singletonList(it)}" />
+      <t:executors computers="${[it]}"/>
     </l:side-panel>
 
     <l:main-panel>


### PR DESCRIPTION
## Remove deprecated jelly singletonList call

Jenkins 2.358 deprecates `Functions.singletonList` because it is not needed from JEXL.

See https://github.com/jenkinsci/jenkins/pull/6740 for more details of the deprecation and the replacement text.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~
