### PR TITLE
Require Jenkins 2.346.3 or newer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,6 @@
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
 buildPlugin(failFast: false,
             configurations: [
-                [platform: 'linux',   jdk: '17', jenkins: '2.346.1'],
+                [platform: 'linux',   jdk: '17', jenkins: '2.361.1'],
                 [platform: 'windows', jdk: '11'],
             ])

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.332.x</artifactId>
+        <artifactId>bom-2.346.x</artifactId>
         <version>1607.va_c1576527071</version>
         <type>pom</type>
         <scope>import</scope>
@@ -71,7 +71,7 @@
     <revision>0.10</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/implied-labels-plugin</gitHubRepo>
-    <jenkins.version>2.332.4</jenkins.version>
+    <jenkins.version>2.346.3</jenkins.version>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <surefire.useFile>false</surefire.useFile>


### PR DESCRIPTION
## Require Jenkins 2.346.3 or newer

90% of installations of the previous plugin version are already using Jenkins 2.346 or newer.

- Require Jenkins 2.346.3 or newer
- Test with Jenkins 2.361.1

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~
