### PR TITLE
Remove temporary javadoc fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,13 +39,6 @@
       <version>2.2</version>
       <scope>test</scope>
     </dependency>
-    <!-- Required for Java 17 Javadoc generation -->
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>3.0.2</version>
-      <scope>provided</scope>
-    </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-auth</artifactId>


### PR DESCRIPTION
## Remove temporary Java 17 javadoc fix

The jsr305 dependency does not seem to be required.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~
