### PR TITLE
Run CI jobs to completion

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,10 +2,14 @@
 
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
 buildPlugin(
+  // Container agents start faster and are easier to administer
   useContainerAgent: true,
+  // Show failures on all configurations
+  failFast: false,
   // Opt-in to the Artifact Caching Proxy, to be removed when it will be in opt-out.
   // See https://github.com/jenkins-infra/helpdesk/issues/2752 for more details and updates.
   artifactCachingProxyEnabled: true,
+  // Test Java 8 with default Jenkins version, Java 11 with a recent LTS, Java 17 even more recent
   configurations: [
     [platform: 'linux',   jdk: '17', jenkins: '2.375'],
     [platform: 'linux',   jdk: '11', jenkins: '2.361.4'],


### PR DESCRIPTION
## Run CI jobs to completion

CI job failures are much more frequently specific to a single configuration than a general purpose failure.  Not enough benefit from failFast to use it.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
