### PR TITLE
Fix plugin name in 'Manage Jenkins' page

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/impliedlabels/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/impliedlabels/Messages.properties
@@ -1,4 +1,4 @@
-displayName=Label implications (i18n)
+displayName=Label implications
 infer_redundant_labels=Infer redundant labels automatically based on user declaration
 inferred_labels=Inferred labels: {0}
 invalid_label_expression=Invalid label expression


### PR DESCRIPTION
## Fix plugin name on 'Manage Jenkins' page

Previously showed "Label implications (i18n)"

Earlier releases showed "Label implications"

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~
