### PR TITLE
Check monthly for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,20 @@
 # Per https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
 updates:
-- package-ecosystem: maven
+- package-ecosystem: "maven"
   directory: "/"
   schedule:
-    interval: weekly
+    interval: "monthly"
   open-pull-requests-limit: 10
-  target-branch: master
   reviewers:
-  - olivergondza
+  - markewaite
+  labels:
+  - skip-changelog
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "monthly"
+  reviewers:
+  - markewaite
   labels:
   - skip-changelog


### PR DESCRIPTION
No need to check dependency updates weekly when releases are infrequent.

Assign reviews to the current maintainer, markewaite, not to the previous one.
