### PR TITLE
Use Palantir format instead of Google Java Format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,12 +81,8 @@
             <!-- define a language-specific format -->
             <java>
               <!-- no need to specify files, inferred automatically -->
-              <!-- apply a specific flavor of google-java-format -->
-              <googleJavaFormat>
-                <version>1.15.0</version>
-                <style>AOSP</style>
-              </googleJavaFormat>
               <endWithNewline />
+              <palantirJavaFormat />
               <removeUnusedImports />
             </java>
             <pom>

--- a/src/main/java/org/jenkinsci/plugins/impliedlabels/Config.java
+++ b/src/main/java/org/jenkinsci/plugins/impliedlabels/Config.java
@@ -67,8 +67,7 @@ public class Config extends ManagementLink {
     private @NonNull List<Implication> implications = Collections.emptyList();
 
     @GuardedBy("configLock")
-    private final transient @NonNull Map<Collection<LabelAtom>, Collection<LabelAtom>> cache =
-            new HashMap<>();
+    private final transient @NonNull Map<Collection<LabelAtom>, Collection<LabelAtom>> cache = new HashMap<>();
 
     private final transient Object configLock = new Object();
 
@@ -106,16 +105,14 @@ public class Config extends ManagementLink {
     }
 
     @POST
-    public void doConfigSubmit(StaplerRequest req, StaplerResponse rsp)
-            throws IOException, ServletException {
+    public void doConfigSubmit(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
         Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         this.implications(
                 req.bindJSONToList(Implication.class, req.getSubmittedForm().get("impl")));
         rsp.sendRedirect("");
     }
 
-    /*package*/ void implications(@NonNull Collection<Implication> implications)
-            throws IOException {
+    /*package*/ void implications(@NonNull Collection<Implication> implications) throws IOException {
         List<Implication> im;
         try {
             im = Collections.unmodifiableList(Implication.sort(implications));
@@ -172,8 +169,7 @@ public class Config extends ManagementLink {
             if (labeler instanceof Implier) continue; // skip Implier
             // Filter out any bad(null) results from plugins
             // for compatibility reasons, findLabels may return LabelExpression and not atom.
-            for (Label label : labeler.findLabels(node))
-                if (label instanceof LabelAtom) result.add((LabelAtom) label);
+            for (Label label : labeler.findLabels(node)) if (label instanceof LabelAtom) result.add((LabelAtom) label);
         }
         return result;
     }

--- a/src/main/java/org/jenkinsci/plugins/impliedlabels/Implication.java
+++ b/src/main/java/org/jenkinsci/plugins/impliedlabels/Implication.java
@@ -109,8 +109,8 @@ public class Implication {
         return Objects.equals(expression, other.expression);
     }
 
-    /*package*/ static @NonNull List<Implication> sort(
-            final @NonNull Collection<Implication> implications) throws CycleDetectedException {
+    /*package*/ static @NonNull List<Implication> sort(final @NonNull Collection<Implication> implications)
+            throws CycleDetectedException {
         CyclicGraphDetector<Implication> sorter = new ImplicationSorter(implications);
 
         sorter.run(implications);

--- a/src/main/java/org/jenkinsci/plugins/impliedlabels/ImpliedLabelsPlugin.java
+++ b/src/main/java/org/jenkinsci/plugins/impliedlabels/ImpliedLabelsPlugin.java
@@ -29,6 +29,9 @@ import hudson.Plugin;
 
 public class ImpliedLabelsPlugin extends Plugin {
 
-    @Extension public static final @NonNull Config config = new Config();
-    @Extension public static final @NonNull Implier implier = new Implier(config);
+    @Extension
+    public static final @NonNull Config config = new Config();
+
+    @Extension
+    public static final @NonNull Implier implier = new Implier(config);
 }

--- a/src/test/java/org/jenkinsci/plugins/impliedlabels/ConfigTest.java
+++ b/src/test/java/org/jenkinsci/plugins/impliedlabels/ConfigTest.java
@@ -67,7 +67,8 @@ public class ConfigTest {
 
     private static final EnvVars NO_ENV = new EnvVars();
 
-    @Rule public JenkinsRule j = new JenkinsRule();
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
 
     private Config config;
     private List<Implication> implications;
@@ -76,13 +77,12 @@ public class ConfigTest {
     @Before
     public void setUp() throws IOException {
         config = ImpliedLabelsPlugin.config;
-        implications =
-                Arrays.asList(
-                        new Implication("rhel64 || rhel65", "rhel6"),
-                        new Implication("rhel4 || rhel5 || rhel6", "rhel"),
-                        new Implication("fedora17 || fedora18", "fedora"),
-                        new Implication("rhel || fedora", "linux"),
-                        new Implication("||", "invalid"));
+        implications = Arrays.asList(
+                new Implication("rhel64 || rhel65", "rhel6"),
+                new Implication("rhel4 || rhel5 || rhel6", "rhel"),
+                new Implication("fedora17 || fedora18", "fedora"),
+                new Implication("rhel || fedora", "linux"),
+                new Implication("||", "invalid"));
         config.implications(implications);
         controllerLabel = j.jenkins.get().getSelfLabel().getName();
     }
@@ -100,9 +100,7 @@ public class ConfigTest {
 
         config.evaluate(j.jenkins);
 
-        assertThat(
-                j.jenkins.getLabelAtoms(),
-                sameMembers(labels("rhel65", "rhel6", "rhel", "linux", controllerLabel)));
+        assertThat(j.jenkins.getLabelAtoms(), sameMembers(labels("rhel65", "rhel6", "rhel", "linux", controllerLabel)));
     }
 
     @Test
@@ -113,18 +111,14 @@ public class ConfigTest {
         config.implications(implications);
         config.evaluate(j.jenkins);
 
-        assertThat(
-                j.jenkins.getLabelAtoms(),
-                sameMembers(labels("rhel65", "rhel6", "rhel", "linux", controllerLabel)));
+        assertThat(j.jenkins.getLabelAtoms(), sameMembers(labels("rhel65", "rhel6", "rhel", "linux", controllerLabel)));
     }
 
     @Test
     public void considerLabelsContributedByOtherLabelFinders() throws IOException {
         j.jenkins.setLabelString("configured");
         config.implications(
-                Collections.singletonList(
-                        new Implication(
-                                "configured && contributed && " + controllerLabel, "final")));
+                Collections.singletonList(new Implication("configured && contributed && " + controllerLabel, "final")));
 
         assertThat(j.jenkins.getLabels(), hasItem(label("final")));
     }
@@ -158,9 +152,7 @@ public class ConfigTest {
         assertThat(config.doCheckExpression(controllerLabel), equalTo(FormValidation.ok()));
         assertThat(config.doCheckExpression("!" + controllerLabel), equalTo(FormValidation.ok()));
 
-        assertThat(
-                config.doCheckExpression("!||&&").getMessage(),
-                containsString("Invalid label expression"));
+        assertThat(config.doCheckExpression("!||&&").getMessage(), containsString("Invalid label expression"));
     }
 
     @PresetData(DataSet.NO_ANONYMOUS_READACCESS)
@@ -247,28 +239,20 @@ public class ConfigTest {
         DumbSlave r6x = j.createSlave("r6x", "rhel6 something_extra", NO_ENV);
 
         for (int i = 0; i < 3; i++) {
-            assertThat(
-                    config.evaluate(f1), sameMembers(labels("fedora17", "fedora", "linux", "f1")));
-            assertThat(
-                    config.evaluate(f2), sameMembers(labels("fedora17", "fedora", "linux", "f2")));
+            assertThat(config.evaluate(f1), sameMembers(labels("fedora17", "fedora", "linux", "f1")));
+            assertThat(config.evaluate(f2), sameMembers(labels("fedora17", "fedora", "linux", "f2")));
             assertThat(config.evaluate(r6), sameMembers(labels("rhel6", "rhel", "linux", "r6")));
-            assertThat(
-                    config.evaluate(r6x),
-                    sameMembers(labels("rhel6", "rhel", "linux", "something_extra", "r6x")));
+            assertThat(config.evaluate(r6x), sameMembers(labels("rhel6", "rhel", "linux", "something_extra", "r6x")));
         }
 
         config.implications(impls);
         tracker.clear();
 
         for (int i = 0; i < 3; i++) {
-            assertThat(
-                    config.evaluate(f1), sameMembers(labels("fedora17", "fedora", "linux", "f1")));
-            assertThat(
-                    config.evaluate(f2), sameMembers(labels("fedora17", "fedora", "linux", "f2")));
+            assertThat(config.evaluate(f1), sameMembers(labels("fedora17", "fedora", "linux", "f1")));
+            assertThat(config.evaluate(f2), sameMembers(labels("fedora17", "fedora", "linux", "f2")));
             assertThat(config.evaluate(r6), sameMembers(labels("rhel6", "rhel", "linux", "r6")));
-            assertThat(
-                    config.evaluate(r6x),
-                    sameMembers(labels("rhel6", "rhel", "linux", "something_extra", "r6x")));
+            assertThat(config.evaluate(r6x), sameMembers(labels("rhel6", "rhel", "linux", "something_extra", "r6x")));
         }
     }
 
@@ -279,15 +263,12 @@ public class ConfigTest {
 
     @Test
     public void testDescription() {
-        assertThat(
-                config.getDescription(),
-                is("Infer redundant labels automatically based on user declaration"));
+        assertThat(config.getDescription(), is("Infer redundant labels automatically based on user declaration"));
     }
 
     @Test
     public void testIconFileName() {
-        assertThat(
-                config.getIconFileName(), is("/plugin/implied-labels/icons/48x48/attribute.png"));
+        assertThat(config.getIconFileName(), is("/plugin/implied-labels/icons/48x48/attribute.png"));
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/impliedlabels/ImplicationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/impliedlabels/ImplicationTest.java
@@ -37,7 +37,8 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 public class ImplicationTest {
 
-    @Rule public JenkinsRule j = new JenkinsRule();
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
 
     @Test
     public void valid() throws IOException {


### PR DESCRIPTION
## Use Palantir format instead of Google Java Format

From https://github.com/jenkinsci/cloud-stats-plugin/pull/68 :

Google Java Format is an excellent formatter for 2-space, 100 line codebases. Its Rectangle Rule has a high degree of conceptual purity, and this works well in the context of 2-space, 100 line codebases where it was designed. If starting from scratch, or if radical changes to existing code style were on the table, this would be my ideal formatter.

For existing 4-space, 120 line codebases where radical changes to existing code style are not on the table, Google Java Format has some critical flaws. Its 4-space "AOSP" mode does not work well at all, and it was not the primary use case. In practice the combination of 4-space mode and the rectangle rule results in unreadable code for lambdas. I have complained about this on the Google Java Format issue tracker for years, but no fix appears to be on the horizon. This makes sense, because Google internally uses the 2-space non-AOSP mode. While various PRs have been submitted to fix this problem, the maintainers of Google Java Format have rejected or ignored them, likely because they all violate the conceptual purity of the Rectangle Rule.

For existing 4-space, 120 line codebases (and the Jenkins project consists largely of these) where radical changes to existing code style are not on the table, Palantir Java Format is a better choice than Google Java Format. It is a fork of Google Java Format designed for this use case with intentional violations of the Rectangle Rule. In practice it gives much better results than Google Java Format for this type of codebase.  

The Maven project is reformatting its legacy codebase with Palantir Java Format and I have been impressed with how relatively uneventful it has been. Palantir Java Format works very well with this type of codebase, and Jenkins is an example of this type of codebase as well. I have successfully reformatted plugin-compat-tester this way in jenkinsci/plugin-compat-tester#506 and the results are far better than Google Java Format.

As the Zen of Python states:

> Practicality beats purity

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
