### PR TITLE
Automate PR review assignment with CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jenkinsci/implied-labels-plugin-developers


### PR DESCRIPTION
## Add CODEOWNERS to request reviews on code changes

[GitHUb documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) describes how CODEOWNERS automates the assignment of pull request reviewers based on file naming patterns.

Created with OpenRewrite command:

```
$ mvn -U org.openrewrite.maven:rewrite-maven-plugin:run \
      -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-jenkins:RELEASE \
      -Drewrite.activeRecipes=org.openrewrite.jenkins.github.AddTeamToCodeowners
```

### Testing done

Confirmed in other repositories that the CODEOWNERS file is a helpful addition.  Rely on GitHub to check the validity of the CODEOWNERS file during the pull request review process.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
