### PR TITLE
Do not reset implied labels when saving global configuration

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/impliedlabels/ImpliedLabelsPlugin.java
+++ b/src/main/java/org/jenkinsci/plugins/impliedlabels/ImpliedLabelsPlugin.java
@@ -78,6 +78,10 @@ public class ImpliedLabelsPlugin extends GlobalConfiguration {
 
     @Override
     public boolean configure(StaplerRequest req, JSONObject jsonObject) throws FormException {
+        // Ignore form submission from configure page ("impl" form) and only save JcasC object with 'impliedLabels'
+        if (jsonObject.containsKey("impl")) {
+            return false;
+        }
         setImplications(Collections.emptyList());
         req.bindJSON(this, jsonObject);
         save();

--- a/src/main/resources/org/jenkinsci/plugins/impliedlabels/ImpliedLabelsPlugin/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/impliedlabels/ImpliedLabelsPlugin/config.jelly
@@ -1,3 +1,9 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <!-- Implied labels are configured from dedicated page but config.jelly required for JcasC support -->
+    <f:form method="post" action="configSubmit">
+        <f:invisibleEntry>
+            <f:textbox name="impl" value="" />
+        </f:invisibleEntry>
+    </f:form>
 </j:jelly>


### PR DESCRIPTION
Saving global configuration was resetting implied label due to introduced configure on #145 

config.jelly is required by JcasC and was empty

Solution I found is to send en empty 'impl' entry and ignore saving object when request received from configure page

Configuration managed by dedicated form page and Config.java is not affected.

I think we should have round trip test to ensure we don't have regression in the future (I will check if I have time to submit on other PR for such test)

### Testing done

Automated tests and mvn:hpi run. Ensuring the implied labels are not removed when saving from global config


```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
