### PR TITLE
Replace bigtable with jenkins-table for consistency

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/impliedlabels/Config/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/impliedlabels/Config/index.jelly
@@ -59,12 +59,14 @@ THE SOFTWARE.
     <l:main-panel>
       <h1>${it.displayName}</h1>
 
-      <table class="pane sortable bigtable">
-        <tr>
-          <th>${%Inferred_labels}</th>
-          <th>${%Expression}</th>
-          <th>${%Size}</th>
-        </tr>
+      <table class="jenkins-table sortable">
+        <thead>
+          <tr>
+            <th initialSortDir="down">${%Inferred_labels}</th>
+            <th>${%Expression}</th>
+            <th>${%Size}</th>
+          </tr>
+        </thead>
         <j:forEach var="implication" items="${it.implications()}">
           <tr>
             <td><local:atoms atoms="${implication.atoms()}"/></td>
@@ -83,11 +85,13 @@ THE SOFTWARE.
       <div><!-- this is where the error message goes --></div>
 
       <h2>${%Redundant_Labels}</h2>
-      <table class="pane sortable bigtable">
-        <tr>
-          <th>${%Node_name}</th>
-          <th>${%Redundant_labels}</th>
-        </tr>
+      <table class="jenkins-table sortable">
+        <thead>
+          <tr>
+            <th initialSortDir="down">${%Node_name}</th>
+            <th>${%Redundant_labels}</th>
+          </tr>
+        </thead>
         <local:redundantLabels node="${app}"/>
         <j:forEach var="node" items="${app.nodes}">
           <local:redundantLabels node="${node}"/>

--- a/src/main/resources/org/jenkinsci/plugins/impliedlabels/Config/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/impliedlabels/Config/index.jelly
@@ -79,7 +79,7 @@ THE SOFTWARE.
       <div style="float:right">
         <input type="button" value="${%Test}" class="yui-button validate-button" onclick="validateButton('${rootURL}/label-implications/inferLabels/${method}','labelString',this)" />
       </div>
-      <div style="display:none;"><img src="${imagesURL}/spinner.gif" /></div>
+      <div style="display:none;"><l:progressAnimation/></div>
       <div><!-- this is where the error message goes --></div>
 
       <h2>${%Redundant_Labels}</h2>


### PR DESCRIPTION
## Replace `bigtable` CSS class with `jenkins-table` for consistency

Use thead tag to identify the heading.  Remove the pane class so that the table is rendered the same as other tables.

### Testing done

Intereactive testing confirms that the table layout appears correct.  Sortable columns behave as expected.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
```
