### PR TITLE
Correct spelling of an internal variable

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/impliedlabels/Config.java
+++ b/src/main/java/org/jenkinsci/plugins/impliedlabels/Config.java
@@ -184,17 +184,17 @@ public class Config extends ManagementLink {
      */
     public @NonNull Collection<LabelAtom> detectRedundantLabels(@NonNull Node node) {
         final @NonNull Set<LabelAtom> initial = initialLabels(node);
-        final @NonNull Set<LabelAtom> infered = new HashSet<>();
+        final @NonNull Set<LabelAtom> inferred = new HashSet<>();
         final @NonNull Set<LabelAtom> accumulated = new HashSet<>(initial);
 
         for (Implication i : implications()) {
             Collection<LabelAtom> ii = i.infer(accumulated);
-            infered.addAll(ii);
+            inferred.addAll(ii);
             accumulated.addAll(ii);
         }
 
-        infered.retainAll(initial);
-        return infered;
+        inferred.retainAll(initial);
+        return inferred;
     }
 
     XmlFile getConfigFile() {


### PR DESCRIPTION
## Correct spelling of an internal variable

The internal variable 'infered' is correct spelled 'inferred'

### Testing done

None.  Rely on ci.jenkins.io test automation.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
