### PR TITLE
[JENKINS-72501] Remove the 'Test' button for implications

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/impliedlabels/Config/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/impliedlabels/Config/index.jelly
@@ -59,7 +59,7 @@ THE SOFTWARE.
     <l:main-panel>
       <h1>${it.displayName}</h1>
 
-      <table class="jenkins-table sortable">
+      <table class="jenkins-table sortable jenkins-!-margin-bottom-0">
         <thead>
           <tr>
             <th initialSortDir="down">${%Inferred_labels}</th>
@@ -75,14 +75,6 @@ THE SOFTWARE.
           </tr>
         </j:forEach>
       </table>
-
-      <h2>${%Test_implications}</h2>
-      <f:textbox name="labelString" autoCompleteDelimChar=" " autoCompleteUrl="${rootURL}/label-implications/autoCompleteLabels" />
-      <div style="float:right">
-        <input type="button" value="${%Test}" class="yui-button validate-button" onclick="validateButton('${rootURL}/label-implications/inferLabels/${method}','labelString',this)" />
-      </div>
-      <div style="display:none;"><l:progressAnimation/></div>
-      <div><!-- this is where the error message goes --></div>
 
       <h2>${%Redundant_Labels}</h2>
       <table class="jenkins-table sortable">


### PR DESCRIPTION
## JENKINS-72501 Remove the 'Test' button for implications

[JENKINS-72501](https://issues.jenkins.io/browse/JENKINS-72501) notes that the "Test" button reports errors in the web development console and does not show any evaluation results.

The [YahooUI removal sheet](https://docs.google.com/spreadsheets/d/1UjvtFmNmEdjMN5DUoFxJfBryA8q-E5_HwOzVKbVG9b0/edit?gid=0#gid=0) notes that implied labels plugin uses the YahooUI button instead of using a standard button.  Rather than convert to a standard button, remove the test and simplify the page.

[JENKINS-73539](https://issues.jenkins.io/browse/JENKINS-73539) is the epic that is working to remove YahooUI from Jenkins.

### Testing done

Confirmed that the "Test" section is removed from the page and that the page renders correctly and without errors in the web developer console.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
