### PR TITLE
Require Jenkins 2.504.3 or newer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,6 @@ buildPlugin(
   forkCount: '1C', // Run a JVM per core in tests
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
-    [platform: 'linux', jdk: 21],
-    [platform: 'windows', jdk: 17],
+    [platform: 'linux', jdk: 25],
+    [platform: 'windows', jdk: 21],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <gitHubRepo>jenkinsci/implied-labels-plugin</gitHubRepo>
     <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.492</jenkins.baseline>
+    <jenkins.baseline>2.504</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
@@ -47,7 +47,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>5473.vb_9533d9e5d88</version>
+        <version>5506.va_222b_131ec34</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
##     Require Jenkins 2.504.3 or newer

https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ recommends the version.  The plugin BOM continues to receive updates for the 2.504.x line.

Switch testing from JDK 17 and 21 to JDK 21 and 25.  Java 17 byte code will continue to be delivered as the release.

### Testing done

Confirmed that automated tests continue to pass.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
