### PR TITLE
[JENKINS-74512] Allow configuration editing when content security policy is enabled

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/impliedlabels/Config/configure.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/impliedlabels/Config/configure.jelly
@@ -43,7 +43,7 @@ THE SOFTWARE.
               <f:entry>
                 <label>${%Labels}<f:textbox value="${impl.atomsString()}" field="atoms" style="width: 30%" autoCompleteDelimChar=" " autoCompleteUrl="${rootURL}/label-implications/autoCompleteLabels"/></label>
                 <st:nbsp/>
-                <labels>${%Expression}<f:textbox value="${impl.expressionString()}" field="expression" checkUrl="'${rootURL}/label-implications/checkExpression?expression='+encodeURIComponent(this.value)" autoCompleteUrl="${rootURL}/label-implications/autoCompleteLabels" autoCompleteDelimChar=" "/></labels>
+                <labels>${%Expression}<f:textbox value="${impl.expressionString()}" field="expression" checkUrl="${rootURL}/label-implications/checkExpression" checkDependsOn="expression" autoCompleteUrl="${rootURL}/label-implications/autoCompleteLabels" autoCompleteDelimChar=" "/></labels>
                 <st:nbsp/>
                 <f:repeatableDeleteButton />
               </f:entry>


### PR DESCRIPTION
## [JENKINS-74512] Allow configuration editing when content security policy is enabled

[JENKINS-74512](https://issues.jenkins.io/browse/JENKINS-74512) notes that the implied labels plugin fails to edit label implications when content security policy is enabled.  The configure page reports that the current user does not have permission to view the page or the page does not exist.

The [developer documentation](https://www.jenkins.io/doc/developer/security/csp/#legacy-javascript-checkurl-validation) describes the steps that were needed to allow the plugin to support content security policy.

### Testing done

* Interactive testing confirmed that modifying the expression with a valid value produces no error message and saves as expected and that modifying with an invalid expression shows a message.  That is the same behavior as the current release
* Automated tests all pass

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
